### PR TITLE
Fix emission payload bugs

### DIFF
--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -231,6 +231,9 @@ func process(emissions []Emission) {
 	for {
 		time.Sleep(processWaitTime)
 		emitWhenReady(emissions)
+		for i, _ := range emissions {
+			emissions[i].EmittableList = []EmitObject{}
+		}
 	}
 }
 
@@ -276,12 +279,15 @@ func emitWhenReady(emissions []Emission) {
 	}
 
 	for _, emission := range emissions {
-		if emission.EmitType == "sqs" {
-			EmitChangesSQS(emission)
-			return
-		}
+		if len(emission.EmittableList) > 0 {
 
-		EmitChanges(emission)
+			if emission.EmitType == "sqs" {
+				EmitChangesSQS(emission)
+				return
+			}
+
+			EmitChanges(emission)
+		}
 	}
 }
 


### PR DESCRIPTION
The multi-endpoint feature introduced a bug whereby objects were being
accumlated and sent repeatedly.  This change empties the slice between
emissions to fix.

Also, the namespace scoping was causing some empty payloads for some
namespace-scoped entpoints.  Now the emittable list is checked and only
sent if it contains objects.

Signed-off-by: Richard Lander <lander2k2@protonmail.com>