### PR TITLE
Expose prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ Configuration for Quartermaster is done via a config file, which, when deployed 
 * `clusterName` Name of the cluster Quartermaster is deployed to.  This is an arbitrary value but should be meaninfgul to the endpoint that is processing the payload, especially when it is receiving reports from multiple clusters.
 * `emitCacheDuration` Amount of time quatermaster should remember it previously emitted an object and that object's state at the given time. Specified with seconds (s), minutes (m), or hours (h).
 * `forceReuploadDuration` Amount of time quartermaster should wait before attempting to re-process all objects inside of kubernetes. If state of object during re-upload hasn't changed since last emit (meaning quartermaster still has a cached record, the object will be dropped). This setting relates to client-go's resyncPeriod Setting this value to 0 ensures no forced re-upload occurs. Specified with seconds (s), minutes (m), or hours (h).
+* `prometheusMetrics` Configuration for exposing prometheus metrics:
+    - `port` The port to expose the metrics on.  This value must be supplied to activate prometheus metrics.  Supply a string or int with a valid port number.
+    - `path` The path at which to expose metrics.  Supply a string including the leading forward slash.  If not defined will default to "/metrics".
 * `remoteEndpoints` An array of destinations to send payloads to. The following can be defined for each endpoint:
     - `type` The type of endpoint.  The following are supported:
         * `http` An HTTP or HTTPS REST API endpoint.

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	ResourcesWatch        []Resource       `yaml:"resources"`
 	NewResources          []Resource
 	StaleResources        []Resource
+	PrometheusMetrics     PrometheusConfig       `yaml:"prometheusMetrics"`
 	ClusterName           string                 `yaml:"clusterName"`
 	DeltaUpdates          bool                   `yaml:"deltaUpdates"`
 	DelayStartSeconds     string                 `yaml:"delayAddEventDuration"`
@@ -51,6 +52,11 @@ type RemoteEndpoint struct {
 	Namespaces  []string `yaml:"namespaces"`
 	UsernameVar string   `yaml:"usernameVar"`
 	PasswordVar string   `yaml:"passwordVar"`
+}
+
+type PrometheusConfig struct {
+	Port string `yaml:"port"`
+	Path string `yaml:"path"`
 }
 
 // ReadConfig reads info from a config file based on the passed configPath.

--- a/examples/quartermaster-config.yaml
+++ b/examples/quartermaster-config.yaml
@@ -12,6 +12,9 @@ data:
     # a cached record, the object will be dropped). This setting relates to client-go's resyncPeriod Setting this value
     # to 0 ensures no forced re-upload occurs. Specified with seconds (s), minutes (m), or hours (h).
     forceReuploadDuration: 500h
+    prometheusMetrics:
+      port: 9595
+      path: /metrics
     remoteEndpoints:
     - type: http
       url: https://appteams.mydomain.com/quartermaster

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	vs_clientset "github.com/heptio/quartermaster/custom/client/clientset/versioned"
 	"github.com/heptio/quartermaster/emitter"
 	"github.com/heptio/quartermaster/kubecluster"
+	"github.com/heptio/quartermaster/metrics"
 	"github.com/heptio/quartermaster/processor"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/workqueue"
@@ -51,6 +52,12 @@ func main() {
 		panic(err.Error())
 	}
 	qmConfig := *parsedConfig
+
+	// expose prometheus metrics if configured
+	merr := metrics.Metrics(qmConfig)
+	if merr != nil {
+		panic(merr.Error())
+	}
 
 	// create workqueue where all objects triggered by events go and start processor that reads
 	// from the queue

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,72 @@
+// Copyright 2018 Heptio
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/golang/glog"
+	"github.com/heptio/quartermaster/config"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	promPort string
+	promPath string
+
+	ProcessCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "quartermaster_objects_processed_count",
+		Help: "Counter of Kubernetes objects processed by Quartermaster.",
+	})
+
+	PayloadCount = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "quartermaster_payloads_sent_count",
+		Help: "Counter of payloads sent to remote endpoint by Quartermaster.",
+	})
+)
+
+// Metrics checks the QM config and if prometheusMetrics.port is configured
+// it registers metrics and exposes them
+func Metrics(qmConfig config.Config) error {
+
+	if qmConfig.PrometheusMetrics.Port == "" {
+		glog.Infoln("prometheus metrics not configured")
+		return nil
+	} else {
+		_, err := strconv.Atoi(qmConfig.PrometheusMetrics.Port)
+		if err != nil {
+			glog.Errorf("%s is not a valid port number for prometheus", qmConfig.PrometheusMetrics.Port)
+		}
+		promPort = ":" + qmConfig.PrometheusMetrics.Port
+
+		if qmConfig.PrometheusMetrics.Port == "" {
+			promPath = "/metrics"
+		} else {
+			promPath = qmConfig.PrometheusMetrics.Path
+		}
+	}
+
+	prometheus.MustRegister(ProcessCount)
+	prometheus.MustRegister(PayloadCount)
+
+	http.Handle(promPath, prometheus.Handler())
+	go func() {
+		glog.Errorf("%s", http.ListenAndServe(promPort, nil))
+	}()
+
+	glog.Infof("prometheus metrics exposed on port %s at path %s", promPort, promPath)
+	return nil
+}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -27,6 +27,7 @@ import (
 	"github.com/heptio/quartermaster/config"
 	"github.com/heptio/quartermaster/emitter"
 	"github.com/heptio/quartermaster/kubecluster"
+	"github.com/heptio/quartermaster/metrics"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -117,6 +118,9 @@ func process(key string) error {
 	}
 	glog.Infof("[%s]: queued to emit", obj.Key)
 	emitter.EmitQueue <- *obj
+
+	// increment objects processed counter for prometheus metrics
+	metrics.ProcessCount.Inc()
 
 	return nil
 }


### PR DESCRIPTION
This change allows prometheus metrics to be optionally exposed with a
configured port number and path.  It includes two quartermaster-specific
metrics: number of processed objects and number of payloads sent.

Signed-off-by: Richard Lander <landerr@vmware.com>