### PR TITLE
Fix metrics path mistake

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -52,7 +52,7 @@ func Metrics(qmConfig config.Config) error {
 		}
 		promPort = ":" + qmConfig.PrometheusMetrics.Port
 
-		if qmConfig.PrometheusMetrics.Port == "" {
+		if qmConfig.PrometheusMetrics.Path == "" {
 			promPath = "/metrics"
 		} else {
 			promPath = qmConfig.PrometheusMetrics.Path


### PR DESCRIPTION
This fixes a typo in the configuration of the metrics path.

Signed-off-by: Richard Lander <landerr@vmware.com>