### PR TITLE
Add configuration options for emissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Configuration for Quartermaster is done via a config file, which, when deployed 
 
 * `clusterName` Name of the cluster Quartermaster is deployed to.  This is an arbitrary value but should be meaninfgul to the endpoint that is processing the payload, especially when it is receiving reports from multiple clusters.
 * `emitCacheDuration` Amount of time quatermaster should remember it previously emitted an object and that object's state at the given time. Specified with seconds (s), minutes (m), or hours (h).
+* `emitBatchMaxObjects` Maximum number of objects to be sent in a single request.  If not defined, default is 10.
+* `emitInterval` Amount of time in seconds that the emissions processor sleeps between sending batches of objects.  When emissions are processed, the number of objects sent is limited by `emitBatchMaxObjects`.  Be aware that if you set `emitBatchMaxObjects` to low and the `emitInterval` too long, it may delay the reporting of changes to resources.  If not defined, default is 1s.
 * `forceReuploadDuration` Amount of time quartermaster should wait before attempting to re-process all objects inside of kubernetes. If state of object during re-upload hasn't changed since last emit (meaning quartermaster still has a cached record, the object will be dropped). This setting relates to client-go's resyncPeriod Setting this value to 0 ensures no forced re-upload occurs. Specified with seconds (s), minutes (m), or hours (h).
 * `prometheusMetrics` Configuration for exposing prometheus metrics:
     - `port` The port to expose the metrics on.  This value must be supplied to activate prometheus metrics.  Supply a string or int with a valid port number.

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,8 @@ type Config struct {
 	DeltaUpdates          bool                   `yaml:"deltaUpdates"`
 	DelayStartSeconds     string                 `yaml:"delayAddEventDuration"`
 	EmitCacheDuration     string                 `yaml:"emitCacheDuration"`
+	EmitBatchMaxObjects   int                    `yaml:"emitBatchMaxObjects"`
+	EmitInterval          int                    `yaml:"emitInterval"`
 	ForceReuploadDuration string                 `yaml:"forceReuploadDuration"`
 	Metadata              map[string]interface{} `yaml:"metadata"`
 	HttpLiveness          HttpLivenessConfig     `yaml:"httpLiveness"`
@@ -132,7 +134,7 @@ func fileWatcher(changed chan bool, file string) {
 		for {
 			info, err := os.Stat(file)
 			if err != nil {
-				glog.Errorf("error accessing file. error: ", err)
+				glog.Errorf("error accessing file. error: %s", err)
 			}
 
 			modTime := info.ModTime()

--- a/examples/quartermaster-config.yaml
+++ b/examples/quartermaster-config.yaml
@@ -7,6 +7,8 @@ data:
   config.yaml: |-
     clusterName: "dev-cluster"
     emitCacheDuration: 14400m
+    emitBatchMaxObjects: 10
+    emitInterval: 1
     # Minutes quartermaster should wait before attempting to re-process all objects inside of kubernetes.
     # If state of object during re-upload hasn't changed since last emit (meaning quartermaster still has
     # a cached record, the object will be dropped). This setting relates to client-go's resyncPeriod Setting this value


### PR DESCRIPTION
This commit includes the addition of two new configuration options:
1. emitBatchMaxObjects: the maximum nuber of obects that can be put
added to an emssion payload.
2. emitInterval: the amount of time between emission payloads being
sent.

Signed-off-by: Richard Lander <landerr@vmware.com>