### PR TITLE
Add ability to ignore namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Configuration for Quartermaster is done via a config file, which, when deployed 
     - `assetId` An arbitrary string that can be used by the remote endpoint to help differentiate resources.
     - `pruneFields` Fields to remove from payload. Used to remove useless or sensitive data that you don't wish to send.
 * `deltaUpdates` Do you wish to send a full object of all the kubernetes resources we are watching, or just the the items have have changed? This is a bool and expects either `true` or `false`.
+* `ignoreNamespaces` An array of namespaces you wish to always ignore.  No events in these namespaces will ever be reported on, even if they are added to the `remoteEndpoints.namespaces`.
 
 ### CLI Parameters
 

--- a/config/config.go
+++ b/config/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	ForceReuploadDuration string                 `yaml:"forceReuploadDuration"`
 	Metadata              map[string]interface{} `yaml:"metadata"`
 	HttpLiveness          HttpLivenessConfig     `yaml:"httpLiveness"`
+	IgnoreNamespaces      []string               `yaml:"ignoreNamespaces"`
 }
 
 type Resource struct {


### PR DESCRIPTION
This change adds a configuration option `ignoreNamespaces` which accepts
an array of namespace names that Quartermaster will ignore altogether.
If configured the informer will not put resources from the specified
namespaces on the queue for emission.

This change also removes the `namespaceSelector` from the InformerClient
as it wasn't being used and, if used, could lead to unpredictable
results with namespace ignoring.

Signed-off-by: Richard Lander <landerr@vmware.com>