### PR TITLE
Allow the use of security context for non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.9
 RUN apk add --no-cache ca-certificates
-RUN mkdir -p /var/lib/quartermaster
 COPY server server
 ENTRYPOINT ["/server"]

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -41,7 +41,7 @@ import (
 
 const (
 	cacheCleanupInterval = 1 * time.Minute
-	cacheFileName        = "/var/lib/quartermaster/cache.gob"
+	cacheFileName        = "/quartermaster/cache.gob"
 	emitObjectMaxDefault = 10
 	emitIntervalDefault  = 1
 )
@@ -252,7 +252,7 @@ func process(emissions []Emission, c config.Config) {
 			emissions[i].EmittableList = []EmitObject{}
 		}
 
-		err := exec.Command("touch", "/emitting").Run()
+		err := exec.Command("touch", "/quartermaster/emitting").Run()
 		if err != nil {
 			glog.Errorf("failed to touch emitting file for liveness check. error: %s", err)
 		} else {

--- a/examples/quartermaster-deploy.yaml
+++ b/examples/quartermaster-deploy.yaml
@@ -13,6 +13,9 @@ spec:
       labels:
         app: quartermaster
     spec:
+      securityContext:
+        runAsUser: 10000
+        fsGroup: 20000
       serviceAccountName: quartermaster-controller
       containers:
       - name: quartermaster
@@ -37,12 +40,14 @@ spec:
         #  exec:
         #    command:
         #    - cat
-        #    - /healthy
+        #    - /quartermaster/healthy
         #  initialDelaySeconds: 25
         #  periodSeconds: 15
         volumeMounts:
         - name: config-volume
           mountPath: /etc/quartermaster
+        - name: scratch-volume
+          mountPath: /quartermaster
         env:
         - name: USERNAME1
           valueFrom:
@@ -68,4 +73,6 @@ spec:
       - name: config-volume
         configMap:
           name: quartermaster
+      - name: scratch-volume
+        emptyDir: {}
 

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -52,7 +52,7 @@ func StartProcessor(resources []config.Resource) {
 
 func runProcessor() {
 	// touch a processing file to indicate processor is running
-	terr := exec.Command("touch", "/processing").Run()
+	terr := exec.Command("touch", "/quartermaster/processing").Run()
 	if terr != nil {
 		glog.Errorf("failed to touch processing file for liveness check. error: %s", terr)
 	} else {
@@ -64,7 +64,7 @@ func runProcessor() {
 	}
 
 	// if processNext() returns false, remove the file to indicate processor has stopped
-	rerr := exec.Command("rm", "/processing").Run()
+	rerr := exec.Command("rm", "/quartermaster/processing").Run()
 	if rerr != nil {
 		glog.Errorf("failed to remove processing file for liveness check. error: %s", rerr)
 	} else {


### PR DESCRIPTION
This change moves the cache and health check files to a /quartermaster
directory that can be mounted on an emptyDir and have a security context
that includes `fsGroup` and does not require root access to write files.

Also inluded and example of how to define a deployment to use an
`emptyDir` scratch volume for cache and health check files.

Signed-off-by: Richard Lander <landerr@vmware.com>