### PR TITLE
Fix emit interval default bug

### DIFF
--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -43,7 +43,7 @@ const (
 	cacheCleanupInterval = 1 * time.Minute
 	cacheFileName        = "/quartermaster/cache.gob"
 	emitObjectMaxDefault = 10
-	emitIntervalDefault  = 1
+	EmitIntervalDefault  = 1
 )
 
 type EmitObject struct {
@@ -239,7 +239,7 @@ func createAWSClient(endpoint config.RemoteEndpoint) *sqs.SQS {
 
 func process(emissions []Emission, c config.Config) {
 
-	processWaitTime := emitIntervalDefault
+	processWaitTime := EmitIntervalDefault
 	if c.EmitInterval != 0 {
 		processWaitTime = c.EmitInterval
 	}

--- a/main.go
+++ b/main.go
@@ -158,8 +158,13 @@ func checkLiveness(qmConfig config.Config) {
 		go httpLiveness(qmConfig)
 	}
 
+	emitInterval := emitter.EmitIntervalDefault
+	if qmConfig.EmitInterval != 0 {
+		emitInterval = qmConfig.EmitInterval
+	}
+
 	for {
-		livenessChecker(qmConfig.EmitInterval)
+		livenessChecker(emitInterval)
 		time.Sleep(10 * time.Second)
 	}
 }


### PR DESCRIPTION
The emit interval default was not being used by the liveness checker so
if the `emitInterval` was not set in the configmap the liveness checker
calculated an invalid unhealthyAge for the emitter and determined that
it was eternally unhealthy.  This commit fixes this bug.

Signed-off-by: Richard Lander <landerr@vmware.com>