### PR TITLE
Add event filtering when processing events to emit

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Configuration for Quartermaster is done via a config file, which, when deployed 
             - `virtualservices`
     - `assetId` An arbitrary string that can be used by the remote endpoint to help differentiate resources.
     - `pruneFields` Fields to remove from payload. Used to remove useless or sensitive data that you don't wish to send.
+    - `filterEvents` An array of events to ignore.  The three events are `add`, `update` and `delete`.  If you don't need to get notified of any of the three events, include here.
 * `deltaUpdates` Do you wish to send a full object of all the kubernetes resources we are watching, or just the the items have have changed? This is a bool and expects either `true` or `false`.
 * `ignoreNamespaces` An array of namespaces you wish to always ignore.  No events in these namespaces will ever be reported on, even if they are added to the `remoteEndpoints.namespaces`.
 

--- a/config/config.go
+++ b/config/config.go
@@ -44,9 +44,10 @@ type Config struct {
 }
 
 type Resource struct {
-	Name        string   `yaml:"name"`
-	AssetId     string   `yaml:"assetId"`
-	PruneFields []string `yaml:"pruneFields"`
+	Name         string   `yaml:"name"`
+	AssetId      string   `yaml:"assetId"`
+	PruneFields  []string `yaml:"pruneFields"`
+	FilterEvents []string `yaml:"filterEvents"`
 }
 
 type RemoteEndpoint struct {

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -417,7 +417,7 @@ func lookupAssetId(resource string) string {
 	return fields
 }
 
-// SetPruneFields accepts a config.Resource that will be used to determine the assetIds that will
+// SetAssetIds accepts a config.Resource that will be used to determine the assetIds that will
 // need to be included when emitting objects.
 func SetAssetIds(resources []config.Resource) {
 	AssetIdLock.Lock()

--- a/examples/quartermaster-config.yaml
+++ b/examples/quartermaster-config.yaml
@@ -49,4 +49,8 @@ data:
       - metadata.generation
       - metadata.annotations
       - status.observedGeneration
+    - name: nodes
+      assetId: no
+      filterEvents:
+      - update
 

--- a/main.go
+++ b/main.go
@@ -140,6 +140,7 @@ func watchConfiguration(ics kubecluster.InformerClients, fileChange chan bool,
 		if len(qmConfig.NewResources) > 0 {
 			addedIcs := kubecluster.StartWatchers(clientset, vsClientset, qmConfig, processor.Queue)
 			processor.SetPruneFields(qmConfig.NewResources)
+			processor.SetFilterEvents(qmConfig.NewResources)
 			emitter.SetAssetIds(qmConfig.NewResources)
 			for _, addedIc := range addedIcs {
 				ics = append(ics, addedIc)


### PR DESCRIPTION
Currently, if you configure quartermaster to watch a particular resource
you will be notified of all unique `add`, `update` and `delete` events.
This change supports the use-case where you only want to be notified of
`add` and `delete` events but not `update` (for example) for a particular
resource.

Signed-off-by: Richard Lander <landerr@vmware.com>