### PR TITLE
Added VMware vRealize Orchestrator endpoint type

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Configuration for Watch-Proxy is done via a config file, which, when deployed to
     - `type` The type of endpoint.  The following are supported:
         * `http` An HTTP or HTTPS REST API endpoint.
         * `sqs` An AWS [Simple Queue Service](https://aws.amazon.com/sqs/) endpoint.
-        * `vro` An HTTP or HTTPS VMware vRealize Orchestrator REST API endpoint.
+        * `vro` An HTTP or HTTPS VMware vRealize Orchestrator REST API endpoint. The target vRO workflow must have an input parameter `input` of type `string`.
     - `url` A standard URL that Watch-Proxy can reach, e.g. https://myendpoint/watch-proxy
     - `usernameVar` A basic auth username used to authenticate at the remote endpoint. If you use this option you must also define an `env` with the same `name` in your deployment manifest, perferably referenced from a secret.
     - `passwordVar` A basic auth password used to authenticate at the remote endpoint. If you use this option you must also define an `env` with the same `name` in your deployment manifest, perferably referenced from a secret.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Configuration for Watch-Proxy is done via a config file, which, when deployed to
     - `type` The type of endpoint.  The following are supported:
         * `http` An HTTP or HTTPS REST API endpoint.
         * `sqs` An AWS [Simple Queue Service](https://aws.amazon.com/sqs/) endpoint.
+        * `vro` An HTTP or HTTPS VMware vRealize Orchestrator REST API endpoint.
     - `url` A standard URL that Watch-Proxy can reach, e.g. https://myendpoint/watch-proxy
     - `usernameVar` A basic auth username used to authenticate at the remote endpoint. If you use this option you must also define an `env` with the same `name` in your deployment manifest, perferably referenced from a secret.
     - `passwordVar` A basic auth password used to authenticate at the remote endpoint. If you use this option you must also define an `env` with the same `name` in your deployment manifest, perferably referenced from a secret.

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -136,7 +136,7 @@ func EmitChanges(emission Emission) {
 	}
 }
 
-// EmitChanges sends a json payload of cluster changes to a remote endpoint
+// EmitChanges sends a json string payload of cluster changes to a vRO remote endpoint
 func EmitChangesVRO(emission Emission) {
 	dataToEmit := []Wrapper{}
 	for _, data := range emission.EmittableList {

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -270,11 +270,7 @@ func StartEmitter(c config.Config, q chan EmitObject) {
 		case "sqs":
 			emission.Svc = createAWSClient(endpoint)
 			emission.SqsUrl = endpoint.Url
-		case "http":
-			emission.HttpUrl = endpoint.Url
-			emission.Username = strings.TrimSuffix(os.Getenv(endpoint.UsernameVar), "\n")
-			emission.Password = strings.TrimSuffix(os.Getenv(endpoint.PasswordVar), "\n")
-		case "vro":
+		case "http", "vro":
 			emission.HttpUrl = endpoint.Url
 			emission.Username = strings.TrimSuffix(os.Getenv(endpoint.UsernameVar), "\n")
 			emission.Password = strings.TrimSuffix(os.Getenv(endpoint.PasswordVar), "\n")

--- a/examples/watch-proxy-config.yaml
+++ b/examples/watch-proxy-config.yaml
@@ -34,6 +34,12 @@ data:
       url: http://echo2/watch-proxy
       usernameVar: USERNAME2
       passwordVar: PASSWORD2
+    #- type: vro
+    #  url: https://vro.example.com/vco/api/workflows/<workflow_id>/executions
+    #  usernameVar: USERNAME2
+    #  passwordVar: PASSWORD2
+    #  resourceTypes:
+    #  - namespaces
     metadata:
       platform: baremetal
       region: east


### PR DESCRIPTION
Added vRO endpoint type. The target vRO workflow must have an input parameter `input` of type `string`.